### PR TITLE
Missing application menu handling

### DIFF
--- a/SteamVRInput/Source/SteamVRInputDevice/Private/SteamVRInputDevice.cpp
+++ b/SteamVRInput/Source/SteamVRInputDevice/Private/SteamVRInputDevice.cpp
@@ -1441,6 +1441,7 @@ void FSteamVRInputDevice::GenerateActionBindings(TArray<FInputMapping> &InInputM
 					CurrentInputKeyName.Contains(TEXT("_A_"));
 				InputState.bIsFaceButton2 = CurrentInputKeyName.Contains(TEXT("FaceButton2"), ESearchCase::CaseSensitive, ESearchDir::FromEnd) ||
 					CurrentInputKeyName.Contains(TEXT("_B_"));
+				InputState.bIsAppMenu = CurrentInputKeyName.Contains(TEXT("_Controller_Application_Press"));
 
 				// Handle Oculus Touch
 				InputState.bIsXButton = InputState.bIsYButton = false;
@@ -1565,6 +1566,10 @@ void FSteamVRInputDevice::GenerateActionBindings(TArray<FInputMapping> &InInputM
 				else if (InputState.bIsYButton)
 				{
 					CachePath = FString(TEXT(ACTION_PATH_BTN_Y_LEFT));
+				}
+				else if (InputState.bIsAppMenu)
+				{
+					CachePath = InputState.bIsLeft ? FString(TEXT(ACTION_PATH_APPMENU_LEFT)) : FString(TEXT(ACTION_PATH_APPMENU_RIGHT));
 				}
 
 				// Handle Special Actions

--- a/SteamVRInput/Source/SteamVRInputDevice/Public/SteamVRInputTypes.h
+++ b/SteamVRInput/Source/SteamVRInputDevice/Public/SteamVRInputTypes.h
@@ -110,6 +110,8 @@ using namespace vr;
 #define ACTION_PATH_PINCH_GRAB_RIGHT	"/user/hand/right/input/pinch"
 #define ACTION_PATH_GRIP_GRAB_LEFT		"/user/hand/left/input/grip"
 #define ACTION_PATH_GRIP_GRAB_RIGHT		"/user/hand/right/input/grip"
+#define ACTION_PATH_APPMENU_LEFT        "/user/hand/left/input/application_menu"
+#define ACTION_PATH_APPMENU_RIGHT        "/user/hand/right/input/application_menu"
 
 
 namespace SteamVRInputDeviceConstants 
@@ -417,6 +419,7 @@ struct FSteamVRInputState
 	bool bIsGripGrab;
 	bool bIsPinchGrab;
 	bool bIsPress;
+	bool bIsAppMenu;
 
 	FSteamVRInputState() {}
 };


### PR DESCRIPTION
This fixes or adds support for the cache path /user/hand/{hand}/input/application_menu, while creating my bindings for my game i notice this was never generated for the vive or wmr - didn't worked either in-game